### PR TITLE
Add stylesheet detection for .scss extension

### DIFF
--- a/src/Codesleeve/AssetPipeline/SprocketsRepository.php
+++ b/src/Codesleeve/AssetPipeline/SprocketsRepository.php
@@ -111,7 +111,7 @@ class SprocketsRepository extends SprocketsTags {
 
 		foreach ($files as $file) {
 			$extension = pathinfo($file, PATHINFO_EXTENSION);
-			if ($extension == 'css' || $extension == 'less') {
+			if ($extension == 'css' || $extension == 'less' || $extension == 'scss') {
 				$filters = $this->getFiltersFor($file);
 				$base = $this->basePath($file);				
 				$assets[] = new FileAsset($this->getFullPath($base, 'stylesheets'), $filters);


### PR DESCRIPTION
I really like this package, but I'm using Sass, so I spent some time trying to add support for it.

Just configuring filters with the extension in `config.php` wasn't enough, because I just couldn't get my `.css.scss` files into `application.css` (At this point, the documentation in README is just plain wrong. Maybe you are already thinking about this in Issue #8, but I thought it is worth pointing out anyway).

Turns out `SprocketsRepository` needs to know about the `.scss` extension to work.

Please add this to support those, who want to use Sass with the asset-pipeline.
