### PR TITLE
Register Blade extensions for javascript and stylesheet tags

### DIFF
--- a/src/Codesleeve/AssetPipeline/AssetPipelineServiceProvider.php
+++ b/src/Codesleeve/AssetPipeline/AssetPipelineServiceProvider.php
@@ -46,7 +46,41 @@ class AssetPipelineServiceProvider extends ServiceProvider {
 		$this->commands('assets.clean');
 	}
 
+	/**
+	 * Boot the service provider.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		$this->registerBladeExtensions();
+	}
 
+	/**
+	 * Register custom blade extensions
+	 *  - @stylesheets()
+	 *  - @javascripts()
+	 *
+	 * @return void
+	 */
+	protected function registerBladeExtensions()
+	{
+		$blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+
+		$blade->extend(function($value, $compiler)
+		{
+			$matcher = $compiler->createMatcher('javascripts');
+
+			return preg_replace($matcher, '$1<?php echo javascript_include_tag$2; ?>', $value);
+		});
+
+		$blade->extend(function($value, $compiler)
+		{
+			$matcher = $compiler->createMatcher('stylesheets');
+
+			return preg_replace($matcher, '$1<?php echo stylesheet_link_tag$2; ?>', $value);
+		});
+	}
 
 	/**
 	 * Get the services provided by the provider.


### PR DESCRIPTION
As discussed in Issue #6, users of Blade can use them like

```
<!DOCTYPE html>
<html>
<head>
  @stylesheets()
  @javascripts('application', ['data-requires' => 'foobar'])
</head>
<body>
<h1>Hello World!</h1>
</body>
</html>
```

Blade compiles this to

```
<!DOCTYPE html>
<html>
<head>
  <?php echo stylesheet_link_tag(); ?>
  <?php echo javascript_include_tag('application', ['data-requires' => 'foobar']); ?>
</head>
<body>
<h1>Hello World!</h1>
</body>
</html>
```
