### PR TITLE
Throw 404 instead of an unhandled exception when an asset isnt found

### DIFF
--- a/src/controllers/AssetPipelineController.php
+++ b/src/controllers/AssetPipelineController.php
@@ -19,8 +19,11 @@ class AssetPipelineController extends Controller {
 		try {
 			$file = Asset::getFullPath($path);
 		} catch (InvalidPath $ex) {
-			//throw a 404 on an invalid path instead of having an unhandled exception
-			App::abort(404);
+			//throw a 404 on an invalid path in production instead of having an unhandled exception
+			if (App::environment() == "production") {
+				App::abort(404);
+			}
+			throw $ex;
 		}
 
 		if (Asset::isJavascript($path)) {


### PR DESCRIPTION
I used to use the "assets" folder for a different purpose and after switching to asset-pipeline, some user-agents are still making requests for files that don't exist anymore. This was triggering hundreds of errors in my inbox because the InvalidPath exception was unhandled

I have modified the AssetPipelineController to return a 404 if the path cannot be found, thereby avoiding this.

I was wondering if the 404 should only be returned in production - what do you think?
