### PR TITLE
Validate file extension

### DIFF
--- a/src/Codesleeve/AssetPipeline/SprocketsRepository.php
+++ b/src/Codesleeve/AssetPipeline/SprocketsRepository.php
@@ -73,7 +73,7 @@ class SprocketsRepository extends SprocketsTags {
 	{
 		try {
 			$file = $this->getFullPath($path, 'javascripts');
-			return $this->filters->hasValidExtension($path) !== false;
+			return $this->filters->hasValidExtension($path, array('js', 'coffee')) !== false;
 		} catch (\Exception $e) {
 
 		}
@@ -92,7 +92,7 @@ class SprocketsRepository extends SprocketsTags {
 	{
 		try {
 			$file = $this->getFullPath($path, 'stylesheets');
-			return $this->filters->hasValidExtension($path) !== false;
+			return $this->filters->hasValidExtension($path, array('css', 'less', 'scss')) !== false;
 		} catch (\Exception $e) {
 			
 		}


### PR DESCRIPTION
on load files in a folder containing: js and css, all files were returned to the same mime type
