### PR TITLE
URLRewrite doesn't rewrite assets in the same directory

### DIFF
--- a/src/Codesleeve/AssetPipeline/Filters/URLRewrite.php
+++ b/src/Codesleeve/AssetPipeline/Filters/URLRewrite.php
@@ -87,10 +87,6 @@ class URLRewrite extends FilterHelper implements FilterInterface
      */
     public function found_file_match($url)
     {
-        $changed = false;
-        $base = $this->base;
-        $root = $this->root;
-
         if ($url[0] != '/' && $this->fileExists($this->root . $url)) {
             return array(true, $this->prefix . $this->base . $url);
         }


### PR DESCRIPTION
The sprite URL in the Chosen library was not being rewritten, for example:

``` css
background: url('chosen-sprite.png') -42px 1px no-repeat;
```

Looks like it's because of this line in the URLRewrite filter:

``` php
if (strpos($url, '/') != 0 && $this->fileExists($this->root . $url)) {
```

`strpos()` returns `false` in this case, so the whole if condition fails.

I think it was supposed to ignore URLs that start with a `/`, so I've changed it to just check the first character instead of searching the whole string.

(I also removed some unused variables - looks like they were copied from `relative_match()` further up.)
