### PR TITLE
Update scssphp version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "leafo/lessphp": "v0.4.0",
         "coffeescript/coffeescript": "1.3.1",
         "nitra/php-min": "dev-master",
-        "leafo/scssphp": "0.0.7"
+        "leafo/scssphp": "0.0.9"
     },
     "require-dev": {
         "mikey179/vfsStream": "1.3.*@dev",


### PR DESCRIPTION
The older version of scssphp has an endless recursion issue when working with large scss libraries (bootstrap, foundation, etc) the latest stable version fixes this.
