### PR TITLE
URLRewrite to set paths as absolute URL

### DIFF
--- a/src/Codesleeve/AssetPipeline/Filters/URLRewrite.php
+++ b/src/Codesleeve/AssetPipeline/Filters/URLRewrite.php
@@ -80,7 +80,7 @@ class URLRewrite extends FilterHelper implements FilterInterface
             return array(false, $url);
         }
 
-        return array(true, $this->prefix . $base . $url);
+        return array(true, url() . $this->prefix . $base . $url);
     }
 
     /**
@@ -94,7 +94,7 @@ class URLRewrite extends FilterHelper implements FilterInterface
     public function found_file_match($url)
     {
         if ($url[0] != '/' && $this->fileExists($this->root . $url)) {
-            return array(true, $this->prefix . $this->base . $url);
+            return array(true, url() . $this->prefix . $this->base . $url);
         }
 
         return array(false, $url);


### PR DESCRIPTION
Related to Issue #98

Example effect of this change:

`background:url(chosen-sprite.png)`
 `background:url(http://localhost/subdirectory/assets/chosen/chosen-sprite.png)`

`src: url('../font/fontawesome-webfont.eot?v=3.2.1');`
`src:url('http://localhost:8000/assets/font-awesome/font/fontawesome-webfont.eot?v=3.2.1')`
