### PR TITLE
Multiple bugs in assets:generate

### DIFF
--- a/src/Codesleeve/AssetPipeline/Commands/AssetsGenerateCommand.php
+++ b/src/Codesleeve/AssetPipeline/Commands/AssetsGenerateCommand.php
@@ -33,12 +33,12 @@ class AssetsGenerateCommand extends Command
 	// since we are spitting out assets
 
         $config = $asset->getConfig();
-	$config['environment'] = $this->option('env');
+	$config['environment'] = ($this->option('env') == '') ? 'production' : $this->option('env');
 	$asset->setConfig($config);
 
-	$generator = new Codesleeve\Sprockets\StaticFileGenerator($asset->getGenerator());
+	$generator = new Codesleeve\Sprockets\StaticFilesGenerator($asset->getGenerator());
  
-        $generated = $generator->generate(public_path() . '/' . $config['routing.prefix']);
+        $generated = $generator->generate(public_path() . '/' . $config['routing']['prefix']);
 
         foreach ($generated as $file)
         {
@@ -55,8 +55,6 @@ class AssetsGenerateCommand extends Command
      */
     protected function getOptions()
     {
-        return array(
-		array('env', 'e', InputOption::VALUE_OPTIONAL, 'What environment should we generate assets for? Default: production', 'production'),
-	);
+        return array();
     }
 }


### PR DESCRIPTION
Bug: `[LogicException] An option named "env" already exists`
Removed the env option and added environment option exists check.

Bug: `Class 'Codesleeve\\Sprockets\\StaticFileGenerator' not found`
`StaticFileGenerator` should be `StaticFilesGenerator`

Bug: `Undefined index: routing.prefix`
`$config['routing.prefix']` changed to `$config['routing']['prefix']`
##### Additional bugs uncovered:

`assets:generate` does not concat files or process directives in application.js/css. Resulting in environments in `concat` config linking to a single, empty application.css/js file. Environments excluded in `concat` are linked to the individual css/js files as expected. 

application.css/js files are empty no matter the `assets:generate` environment.

`assets:clean` throws:

```
{
   "error":{
      "type":"Symfony\\Component\\Debug\\Exception\\FatalErrorException",
      "message":"Cannot access private property Codesleeve\\AssetPipeline\\AssetPipeline::$parser",
      "file":"C:\\xampp\\htdocs\\brands\\vendor\\codesleeve\\asset-pipeline\\src\\Codesleeve\\AssetPipeline\\Commands\\AssetsCleanCommand.php",
      "line":74
   }
}
```
