### PR TITLE
Capitalise Laravel in the command description

### DIFF
--- a/src/Codesleeve/AssetPipeline/Commands/AssetsSetupCommand.php
+++ b/src/Codesleeve/AssetPipeline/Commands/AssetsSetupCommand.php
@@ -18,7 +18,7 @@ class AssetsSetupCommand extends Command
      *
      * @var string
      */
-    protected $description = "Setup the default asset pipeline folders in your new laravel project";
+    protected $description = "Setup the default asset pipeline folders in your new Laravel project";
 
     /**
      * Execute the console command.


### PR DESCRIPTION
A bit of a lame PR I know, but the lowercase L was starting to annoy me.

Hopefully can contribute something with a little more substance in the future!
