### PR TITLE
CoffeeScript filter custom config

### DIFF
--- a/src/Codesleeve/AssetPipeline/Filters/CoffeeScript.php
+++ b/src/Codesleeve/AssetPipeline/Filters/CoffeeScript.php
@@ -6,13 +6,11 @@ use CoffeeScript\Compiler;
 
 class CoffeeScript implements FilterInterface
 {
-    var $config = array();
-    public function __construct($config=null)
+    var $config;
+    
+    public function __construct($config=array())
     {
-	if($config)
-	{
-		$this->config = $config;
-	}
+	$this->config = $config;
     }
 
     public function filterLoad(AssetInterface $asset)
@@ -24,7 +22,7 @@ class CoffeeScript implements FilterInterface
     {
         $content = $asset->getContent();
         
-        $config = array_merge(array('filename' => $asset->getSourcePath()), $this->config);
+        $config = array_merge( array( 'filename' => $asset->getSourcePath() ), $this->config );
 
 		$content = Compiler::compile($content, $config);
 


### PR DESCRIPTION
Added loading custom config to the CoffeeScript parser, to use it via package configuration. Example:

``` php
...
'filters' => array(
        '.coffee' => array(
            new Codesleeve\AssetPipeline\Filters\CoffeeScript(array('bare' => true)),
            new EnvironmentFilter(new Codesleeve\AssetPipeline\Filters\JSMinPlusFilter, App::environment()),
        )
...
```
