### PR TITLE
Move route creation to boot() method.

### DIFF
--- a/src/Codesleeve/AssetPipeline/AssetPipelineServiceProvider.php
+++ b/src/Codesleeve/AssetPipeline/AssetPipelineServiceProvider.php
@@ -22,8 +22,6 @@ class AssetPipelineServiceProvider extends ServiceProvider {
 	{
 		$this->package('codesleeve/asset-pipeline');
 
-		include __DIR__.'/../../routes.php';
-
 		include_once __DIR__.'/AssetPipelineGlobalHelpers.php';
 
 		$this->app['asset'] = $this->app->share(function($app)
@@ -44,19 +42,19 @@ class AssetPipelineServiceProvider extends ServiceProvider {
 		});
 
 		$this->app['assets.setup'] = $this->app->share(function($app)
-        {
-            return new Commands\AssetsSetupCommand;
-        });
+		{
+			return new Commands\AssetsSetupCommand;
+		});
 
 		$this->app['assets.clean'] = $this->app->share(function($app)
-        {
-            return new Commands\AssetsCleanCommand;
-        });
+		{
+			return new Commands\AssetsCleanCommand;
+		});
 
 		$this->app['assets.generate'] = $this->app->share(function($app)
-        {
-            return new Commands\AssetsGenerateCommand;
-        });
+		{
+			return new Commands\AssetsGenerateCommand;
+		});
 
 		$this->commands('assets.setup');
 		$this->commands('assets.clean');
@@ -70,6 +68,8 @@ class AssetPipelineServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
+		include __DIR__.'/../../routes.php';
+
 		$this->registerBladeExtensions();
 	}
 


### PR DESCRIPTION
This had the potential to cause complications in combination with other packages.

Resolving objects from the container (as using a facade always does) should always be done in `boot()`, so that other packages have the chance to either use `Container::extend()` or `Container::resolving()` on these objects.

Also did some whitespace cleanup.
