### PR TITLE
Platform independent new line replacement for JST templates

### DIFF
--- a/src/Codesleeve/AssetPipeline/Filters/JST.php
+++ b/src/Codesleeve/AssetPipeline/Filters/JST.php
@@ -21,7 +21,7 @@ class JST extends FilterHelper implements FilterInterface
         $filename =  pathinfo($asset->getSourcePath(), PATHINFO_FILENAME);
 
     	$content = str_replace('"', '\\"', $asset->getContent());
-    	$content = str_replace(PHP_EOL, "", $content);
+        $content = preg_replace("/[\r?\n]+/", "", $content);
 
     	$jst = 'JST = (typeof JST === "undefined") ? JST = {} : JST;' . PHP_EOL;
     	$jst .= 'JST["' . $relativePath . $filename . '"] = "';


### PR DESCRIPTION
PHP_EOL will basically only replace \n, at least when running on *nix based server, so if template files are using Windows style line breaks (\r\n), they will not be minified to one line, causing JS errors as referenced in issue #190. This will replace any kind of line break (\n, \r\n or just \r).
